### PR TITLE
修改示例代码中的不正确内容

### DIFF
--- a/docs/quick/steps/controller.md
+++ b/docs/quick/steps/controller.md
@@ -583,7 +583,7 @@ public class BlogController : AdminApiController
     [ModuleInfo]
     [DependOnFunction("Read")]
     [UnitOfWork]
-    [Description("申请")]
+    [Description("审核")]
     public async Task<AjaxResult> Verify(BlogVerifyDto dto)
     {
         Check.NotNull(dto, nameof(dto));


### PR DESCRIPTION
修改审核博客API描述为 `[Description("申请")]`导致的启动时出错。